### PR TITLE
Fix calculator button inconsistencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
             <button class="operator">AC</button>
             <button class="operator">DEL</button>
             <button class="operator">%</button>
-            <button class="operator"> /</button>
+            <button class="operator">/</button>
         </div>
         <div>
             <button>7</button>
@@ -35,12 +35,13 @@
             <button class="operator">+</button>
         </div>
         <div>
-            <button>O0</button>
+            <button>00</button>
             <button>0</button>
-            <button>,</button> 
+            <button>.</button> 
             <button class="equalbtn">=</button>
         </div>
     </div>
     <script src="script.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## 📌 Description
Fix minor inconsistencies in the calculator HTML file.
Corrected button labels.

---

## 🔗 Related Issue
Closes #8 

---

## 🛠 Changes Made
- Replaced "O0" button with "00"
- Changed comma (,) to decimal point (.)
- Removed extra space in "/" button
---

## 🧪 How to Test
1. Open the calculator in a browser.
2. Verify that the "00" button displays correctly.
3. Check that the decimal button uses "." instead of ",".
4. Ensure the divide button has no extra spacing.
5. Confirm that the input field cannot be typed into manually.

---

## 📷 Screenshots (if applicable)

---

## ✅ Checklist
- [✅ ] I have tested my changes
- [✅ ] I have linked the related issue
- [✅ ] My code follows project guidelines
