### PR TITLE
fix: align calculator grid layout and fix UI inconsistencies

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,16 +1,15 @@
 .calc{
     width: 350px;
-    height: 450px;
     background: rgb(0, 0, 0);
-    margin-left: 40%;
-    margin-top: 45px;
+    margin: 0;
     padding: 15px;
     text-align: center;
 }
 
 
 input {
-  width: 80%;
+  width: 100%;
+  box-sizing: border-box;
   border-color:white;
   padding: 15px;
   margin-top: 10px;
@@ -35,7 +34,7 @@ button {
   border-radius: 45%;
   background-color: #2c2c2c;
   color: white;
-  font-size: 18px;
+  font-size: 12px;
   transition: 0.2s ease;
   cursor: pointer;
 }
@@ -70,6 +69,12 @@ body {
     background-color: var(--bg-color);
     color: var(--text-color);
     transition: 0.3s ease;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    margin: 0;
 }
 .calc {
     background-color: var(--calc-bg);
@@ -77,16 +82,28 @@ body {
     border-radius: 12px;
     box-shadow: 0 5px 15px rgba(0,0,0,0.2);
 }
-button {
+
+.row {
+  display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+    margin: 4px 0;
+}
+
+.row button {
+    width: 100%;
+    height: 60px;
     background-color: var(--btn-bg);
     border: none;
+    color: white;
     padding: 10px;
-    margin: 10px;
+    margin: 0;
     font-size: 12px;
     border-radius: 9px;
     cursor: pointer;
-    transition: 0.2s;
+    transition: 0.2s ease;
 }
+
 button:hover {
     transform: scale(1.05);
 }
@@ -96,5 +113,30 @@ button:hover {
 }
 .theme-controls {
     text-align: center;
-    margin: 20px;
+    margin-bottom: 16px;
+    display: flex;
+    width: 70%;
+    justify-content: flex-start;
+}
+
+#themeToggle {
+    background-color: #2c2c2e;
+    color: white;
+    border: none;
+    border-radius: 12px;
+    padding: 5px 10px;
+    font-size: 14px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    width: 70px;
+    line-height: 1.2;
+}
+
+#themeToggle:hover {
+    background-color: #3a3a3c;
+    transform: scale(1.05);
+    transition: 0.2s ease;
 }


### PR DESCRIPTION
## 📌 Description
Fixes multiple layout and UI inconsistencies in the calculator page,  including misaligned operator buttons, overflowing input field, inconsistent button sizing, and a misaligned theme toggle button.
---

## 🔗 Related Issue
Closes #17 
---

## 🛠 Changes Made
- Fixed operator button alignment by adding `display: grid` with 4 equal columns to `.row`
- Replaced `margin-left: 40%` with flexbox centering on `body` for consistent layout
- Fixed input field overflow using `box-sizing: border-box`
- Unified button `border-radius` and sizing for a consistent look across all buttons
- Fixed conflicting duplicate CSS rule blocks for `.calc ` and `button`
- Styled and aligned theme toggle button to sit flush with the calculator
---

## 🧪 How to Test
Explain how reviewers can test your changes.
1. Open `index.html` in a browser
2. Verify operator buttons (`/`, `*`, `-`, `+`) are aligned in the 4th column of the grid
3. Verify the input field does not overflow the calculator container
4. Verify the theme toggle button is aligned above the calculator
5. Toggle between light and dark mode and confirm layout holds in both
---

## 📷 Screenshots (if applicable)
**Before:**
<img width="1690" height="983" alt="Screenshot 2026-02-22 165714" src="https://github.com/user-attachments/assets/97536f9c-256e-4090-bf59-a8b14bc07b9b" />

**After:**
<img width="1891" height="992" alt="image" src="https://github.com/user-attachments/assets/9bfc2959-0bd4-434b-96e0-306c64d388e7" />
---

## ✅ Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] My code follows project guidelines
