### PR TITLE
DEL key bug fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -146,14 +146,6 @@ input.addEventListener("keypress", (e) => {
     }
 });
 
-//block user from typing invalid keys like alphabets and special chars like @ # $
-const allowedKeys = "0123456789+-*/().";
-input.addEventListener("keypress", function(e){
-    if(!allowedKeys.includes(e.key)){
-        e.preventDefault();
-    }
-});
-
 // Allow pasting values into the calculator (e.g. a copied result)
 input.addEventListener("paste", (e) => {
     e.preventDefault();
@@ -164,4 +156,5 @@ input.addEventListener("paste", (e) => {
         input.value = string;
         hideCopyBtn();
     }
+
 });


### PR DESCRIPTION
## 📌 Description
This one was suppose to be just the bug fix for the `DEL` key removing 2 char instead of just 1, but had to fix the bug with the input box showing the dark/light mode too.

---

## 🔗 Related Issue
Closes #31 

---

## 🛠 Changes Made
- Fixed the issue with the input box showing light/dark mode when toggling by updating the `querySelectorAll` from `"button"` to `".calc button"`.
- Updated `string.slice(0, string.length - 2);` to `string.slice(0, string.length - 1);` for the `DEL` key bug.
- Also removed the line `const display = document.getElementById("inputBox");` and updated `display.addEventListener("keypress", function(e){` to `input.addEventListener("keypress", function(e){` for avoiding duplicate elements for `"inputBox"` in code.

---

## 🧪 How to Test

1. Open `index.html` in a browser.
2. Type something like `1234` and try pressing the `DEL` key.
3. You should see only 1 char from the end getting deleted.

---

## 📷 Screenshots (if applicable)

### Initial
<img width="1919" height="955" alt="image" src="https://github.com/user-attachments/assets/549e112a-0313-4dfb-a4e5-336eba4669ef" />

### Final
<img width="1919" height="956" alt="image" src="https://github.com/user-attachments/assets/c2ebe271-748d-49c8-9416-ed10654ab19a" />

---

## ✅ Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] My code follows project guidelines