### PR TITLE
feat: add copy button to copy calculator result to clipboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,12 @@
 
 <div class="main-body">
     <div class="calc">
-        <input type="text" placeholder="0" id="inputBox">
+
+        <!-- Display wrapper holds both the input and the copy button -->
+        <div class="display-wrapper">
+            <input type="text" placeholder="0" id="inputBox">
+            <button id="copyBtn" class="copy-btn" title="Copy result" aria-label="Copy result">📋</button>
+        </div>
 
         <div class="row">
             <button class="operator">AC</button>
@@ -55,4 +60,3 @@
 
 <script src="script.js"></script>
 </body>
-</html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,44 @@
 let input = document.getElementById("inputBox");
-let buttons = document.querySelectorAll("button");
+let buttons = document.querySelectorAll("button:not(#copyBtn)");
 let string = "";
+
+// ==================== COPY BUTTON ====================
+const copyBtn = document.getElementById("copyBtn");
+let copyTimeout = null;
+
+/** Shows the copy button — called whenever a result is ready on the display */
+function showCopyBtn() {
+    copyBtn.style.display = "block";
+}
+
+/** Hides the copy button — called on AC or when display is cleared */
+function hideCopyBtn() {
+    copyBtn.style.display = "none";
+    copyBtn.textContent = "📋";
+    copyBtn.classList.remove("copied");
+    clearTimeout(copyTimeout);
+}
+
+copyBtn.addEventListener("click", () => {
+    const result = input.value;
+    if (!result || result === "Error") return;
+
+    navigator.clipboard.writeText(result).then(() => {
+        // Show "Copied!" feedback briefly, then restore the icon
+        copyBtn.textContent = "Copied!";
+        copyBtn.classList.add("copied");
+        clearTimeout(copyTimeout);
+        copyTimeout = setTimeout(() => {
+            copyBtn.textContent = "📋";
+            copyBtn.classList.remove("copied");
+        }, 2000);
+    }).catch(() => {
+        // Fallback for browsers where clipboard write fails
+        input.select();
+        document.execCommand("copy");
+    });
+});
+// =====================================================
 
 // Factorial function
 function factorial(n) {
@@ -21,41 +59,52 @@ buttons.forEach((button) => {
                 string = eval(string);
                 input.value = string;
                 string = "";
+                showCopyBtn(); // result is ready
             } catch {
                 input.value = "Error";
                 string = "";
+                hideCopyBtn();
             }
         }
 
         else if (value === "AC") {
             string = "";
             input.value = "";
+            hideCopyBtn(); // clear resets everything
         }
 
         else if (value === "DEL") {
             string = string.slice(0, -1);
             input.value = string;
+            // Hide copy button if display is cleared by DEL
+            if (!string) hideCopyBtn();
         }
 
         else if (value === "√") {
             let num = parseFloat(input.value);
             if (num < 0 || isNaN(num)) {
                 input.value = "Error";
+                hideCopyBtn();
             } else {
                 input.value = Math.sqrt(num);
+                string = "";
+                showCopyBtn(); // result is ready
             }
-            string = "";
         }
 
         else if (value === "!") {
             let num = parseFloat(input.value);
-            input.value = factorial(num);
+            let result = factorial(num);
+            input.value = result;
             string = "";
+            if (result !== "Error") showCopyBtn(); // result is ready
+            else hideCopyBtn();
         }
 
         else {
             string += value;
             input.value = string;
+            hideCopyBtn(); // user is still typing, hide the button
         }
     });
 });
@@ -67,9 +116,11 @@ document.addEventListener("keydown", (e) => {
             string = eval(input.value);
             input.value = string;
             string = "";
+            showCopyBtn(); // result is ready
         } catch {
             input.value = "Error";
             string = "";
+            hideCopyBtn();
         }
     }
 });
@@ -79,5 +130,17 @@ const allowedKeys = "0123456789+-*/().!";
 input.addEventListener("keypress", (e) => {
     if (!allowedKeys.includes(e.key)) {
         e.preventDefault();
+    }
+});
+
+// Allow pasting values into the calculator (e.g. a copied result)
+input.addEventListener("paste", (e) => {
+    e.preventDefault();
+    const pasted = (e.clipboardData || window.clipboardData).getData("text");
+    // Only allow if the pasted text is a valid number
+    if (!isNaN(pasted) && pasted.trim() !== "") {
+        string = pasted.trim();
+        input.value = string;
+        hideCopyBtn();
     }
 });

--- a/style.css
+++ b/style.css
@@ -12,16 +12,59 @@ body {
     text-align: center;
 }
 
+/* Wraps the input + copy button together */
+.display-wrapper {
+    position: relative;
+    margin-bottom: 15px;
+}
+
 input {
     width: 90%;
     padding: 15px;
+    padding-right: 44px; /* make room for the copy button */
     font-size: 26px;
     text-align: right;
-    margin-bottom: 15px;
     background: transparent;
     color: white;
     border: 2px solid white;
     border-radius: 8px;
+    box-sizing: border-box;
+}
+
+/* Copy button — sits inside the display border, top-left corner */
+.copy-btn {
+    position: absolute;
+    top: 50%;
+    left: 18px;
+    transform: translateY(-50%);
+    width: 36px;
+    height: 36px;
+    margin: 0;
+    padding: 0;
+    font-size: 22px;
+    line-height: 28px;
+    border-radius: 6px;
+    background: transparent;
+    color: white;
+    border: none;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.2s, background 0.2s;
+
+    /* Hidden by default — shown only when a result exists */
+    display: none;
+}
+
+.copy-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+    opacity: 1;
+}
+
+/* "Copied!" state */
+.copy-btn.copied {
+    font-size: 10px;
+    opacity: 1;
+    color: #0ab448;
 }
 
 button {


### PR DESCRIPTION
## 📌 Description
Briefly describe what this PR does.
Adds a 📋 copy button to the calculator display that lets users copythe result to their clipboard with one click. Also supports pasting the copied value back into the calculator for chained calculations.


## 🔗 Related Issue
Closes #42 



## 🛠 Changes Made
- Added a copy button (📋) inside the display, hidden by default
- Button appears only when a result is ready (after =, √, !)
- Shows "Copied!" confirmation for 2 seconds after clicking
- Button hides again when user starts a new calculation
- Added paste support so copied results can be pasted back into the calculator


## 🧪 How to Test
Explain how reviewers can test your changes.
1. Open the calculator in your browser
2. Enter any calculation (e.g. 25 + 5) and press =
3. A 📋 button should appear on the left side of the display
4. Click 📋 — it should briefly show "Copied!" in green, then revert to 📋
5. Open any app (Notepad, Google Docs, etc.) and press Ctrl+V — the result should paste correctly
6. Back in the calculator, press Ctrl+V on the display — the copied number should load in ready for the next calculation (e.g. type * 2 and press = to continue)
7. Press AC — the 📋 button should disappear
8. Verify the 📋 button does NOT appear on page load (display is empty)
9. Verify the 📋 button does NOT appear while typing (only after a result)

## 📷 Screenshots (if applicable)
result is copied:
<img width="736" height="768" alt="image" src="https://github.com/user-attachments/assets/45743cf0-350e-4898-8b8d-0348d5afcb74" />



## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue