### PR TITLE
Validating Pasted expressions in the calculator text-box (allows pasting numeric expressions, prevents text data)

### DIFF
--- a/script.js
+++ b/script.js
@@ -185,11 +185,28 @@ input.addEventListener("keypress", (e) => {
     }
 });
 
-// Allow pasting and keep string in sync
+// Function to validate if pasted content contains only allowed characters
+function isValidExpression(expression) {
+    const allowedChars = /^[0-9+\-*/(). √!]*$/;
+    return allowedChars.test(expression);
+}
+
+// Allow pasting and keep string in sync with validation
 input.addEventListener("paste", (e) => {
-    setTimeout(() => {
-        string = input.value;
+    e.preventDefault();
+    const pasted = (e.clipboardData || window.clipboardData).getData("text");
+    
+    // Validate the pasted content
+    if (isValidExpression(pasted)) {
+        string = pasted;
+        input.value = string;
         resultJustCalculated = false;
         hideCopyBtn();
-    }, 0);
+    } else {
+        // Show error if invalid characters are detected
+        input.value = "Invalid expression";
+        string = "";
+        resultJustCalculated = false;
+        hideCopyBtn();
+    }
 });


### PR DESCRIPTION
##  Description
The current calculator web app does not allow users to paste anything into the calculator textbox. It does not allow pasting any numeric expression and any text expression with letters. This PR checks if the expressions pasted into the inputbox of the calculator contains invalid characters(like letters or special symbols : @ # etc..) If the expression copied to clipboard and pasted to the calculator inputBox is a numeric expression (ie, it contains only numbers, eg: 4+5 / 2 -1) then that expression is evaluated correctly but if it contains invalid characters then the calculator inputBox does not display that expression, it shows a message "Invalid expression" so that the user can understand that the expression he/she  pasted is not supported by the calculator. 

## 🔗 Related Issue
Closes #46

## Changes Made
- checks and validates expressions pasted from clipboard
- restored other basic calculator functions which were buggy
- added a calculateResult() fn to separate expression evaluation logic from other calculator functions

##  How to Test
- pull this branch open the project folder and run the calculator by opening index.html in a browser.
- Verify the following:
- try to paste an expression  like abcdefg@3+2, the text box will show invalid expression
- try to paste an expression like 3+2/5-1, the calculator displays the expression in the inputbox and result is calculated if = or Enter key is pressed 