### PR TITLE
Fixed the issue with All symbols being allowed in the start of an expression

### DIFF
--- a/script.js
+++ b/script.js
@@ -120,9 +120,9 @@ buttons.forEach((button) => {
             result !== "Error" ? showCopyBtn() : hideCopyBtn();
         }
 
-        else {
-            // Prevent double operators
+        else if (value === "+" || value === "-" || (string !== "" && !isNaN(value))) {
             if ("+-*/".includes(value) && "+-*/".includes(string.slice(-1))) {
+                if (string.length === 1 && !"+-".includes(value)) return;
                 string = string.slice(0, -1);
             }
 
@@ -179,15 +179,18 @@ document.addEventListener("keydown", (e) => {
 const allowedKeys = "0123456789+-*/().!";
 
 input.addEventListener("keydown", (e) => {
-    if (
-        !allowedKeys.includes(e.key) &&
-        e.key !== "Backspace" &&
-        e.key !== "Delete" &&
-        e.key !== "Enter" &&
-        e.key !== "ArrowLeft" &&
-        e.key !== "ArrowRight"
-    ) {
+    if (["Backspace", "Delete", "ArrowLeft", "ArrowRight", "Enter", "Tab"].includes(e.key)) return;
+    
+    const isAtStart = input.selectionStart === 0;
+    const isOp = "+-*/".includes(e.key);
+    const lastOp = "+-*/".includes(input.value.slice(-1));
+
+    if ((isAtStart && !"+-".includes(e.key)) || !allowedKeys.includes(e.key)) return e.preventDefault();
+
+    if (isOp && lastOp && input.selectionStart === input.value.length) {
+        if (input.value.length === 1 && !"+-".includes(e.key)) return e.preventDefault();
         e.preventDefault();
+        input.value = string = input.value.slice(0, -1) + e.key;
     }
 });
 // =====================================================


### PR DESCRIPTION
## 📌 Description
This PR fixes the issue with All symbols being allowed in the start of an expression. Now it only allows either `-` or `+` in the start.

---

## 🔗 Related Issue
Closes #43 

---

## 🛠 Changes Made
- Only inputs the symbol initially if its either `-` or `+`
- Only 1 symbol is allowed in the start now
- Same for keyboard input too

---

## 🧪 How to Test

1. Open `index.html` in your browser
2. Try typing all the symbols using the UI and keyboard
3. it should only show `-` or `+` for the first part.
4. Eg: `-2+2` or `+2-2`

---

## 📷 Screenshots (if applicable)
<img width="1919" height="955" alt="image" src="https://github.com/user-attachments/assets/cca532fa-c093-4ea5-8c3d-6ee5445f0a8e" />
<img width="1919" height="961" alt="image" src="https://github.com/user-attachments/assets/64a4a154-6d4b-4a64-82c9-2192f25a04e4" />

---

## ✅ Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] My code follows project guidelines
